### PR TITLE
Fixes for menu separator, search box and messengerCompose

### DIFF
--- a/themes/_base.css
+++ b/themes/_base.css
@@ -267,3 +267,8 @@ thumb:hover {
 .emailStar {
 	margin-inline-start: 2px !important;
 }
+
+menuseparator{
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+}

--- a/themes/_base.css
+++ b/themes/_base.css
@@ -267,8 +267,3 @@ thumb:hover {
 .emailStar {
 	margin-inline-start: 2px !important;
 }
-
-menuseparator{
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-}

--- a/themes/dark.css
+++ b/themes/dark.css
@@ -86,8 +86,9 @@
 	}
 }
 
-#composeToolbar2{
-    background: var(--dark-color) !important;
+#compose-toolbox, #compose-toolbox > *, #ab-toolbox {
+	-moz-appearance: none !important;
+	background: var(--dark-color) !important;
 }
 
 .tabmail-tab[selected="true"] .tab-content {
@@ -98,8 +99,8 @@
 	color: var(--dark-light-text-color) !important;
 }
 
-.toolbarbutton-1, .toolbarbutton-menubutton-button, #composeToolbar2{
-    color: var(--dark-text-color) !important;
+.chromeclass-toolbar, .chromeclass-toolbar * {
+	color: var(--dark-text-color) !important;
 }
 
 menu label, menuitem label, .splitmenu-menuitem label, menucaption label,

--- a/themes/dark.css
+++ b/themes/dark.css
@@ -86,9 +86,8 @@
 	}
 }
 
-#compose-toolbox, #compose-toolbox > *, #ab-toolbox {
-	-moz-appearance: none !important;
-	background: var(--dark-color) !important;
+#composeToolbar2{
+    background: var(--dark-color) !important;
 }
 
 .tabmail-tab[selected="true"] .tab-content {
@@ -99,8 +98,8 @@
 	color: var(--dark-light-text-color) !important;
 }
 
-.chromeclass-toolbar, .chromeclass-toolbar * {
-	color: var(--dark-text-color) !important;
+.toolbarbutton-1, .toolbarbutton-menubutton-button, #composeToolbar2{
+    color: var(--dark-text-color) !important;
 }
 
 menu label, menuitem label, .splitmenu-menuitem label, menucaption label,


### PR DESCRIPTION
This PR fixes these issues:
- menu separators have now a normal height (issue #65 )
- the text into the search box is now visible (dark theme only)
- the first toolbar in messengerCompose is now with a grey background so the text on it is visible (dark theme only)