### PR TITLE
Fixes for the menu text color (monterail)

### DIFF
--- a/themes/monterail.css
+++ b/themes/monterail.css
@@ -104,9 +104,12 @@
 	color: var(--monterail-light-text-color) !important;
 }
 
-menu label, menuitem label, .splitmenu-menuitem label, menucaption label,
-.chromeclass-toolbar menu label, .chromeclass-toolbar menuitem label, .chromeclass-toolbar .splitmenu-menuitem label, .chromeclass-toolbar menucaption label {
-	color: var(--monterail-text-color) !important;
+#navigation-toolbox .menubar-text, .splitmenu-menuitem label, menucaption label, .chromeclass-toolbar menu label, .chromeclass-toolbar menuitem label, .chromeclass-toolbar .splitmenu-menuitem label, .chromeclass-toolbar menucaption label {
+  color: var(--monterail-text-color) !important;
+}
+
+#compose-toolbox .menubar-text{
+  color: var(--monterail-light-text-color) !important;
 }
 
 menupopup {


### PR DESCRIPTION
This PR changes the text color from black to white in the "messengerCompose" menu.
Issue: #59 

@jdreesen as I promised you, the fix for monterail.