### PR TITLE
White buttons for close folderView and for titleBar (all themes)

### DIFF
--- a/themes/dark.css
+++ b/themes/dark.css
@@ -138,6 +138,8 @@ menuseparator {
 	border-bottom: 1px solid rgba(127,127,127,0.2) !important;
 }
 
+/*---- Titlebar button ----*/
+
 #titlebar-min {
     list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#minimize-white) !important;
 }
@@ -152,4 +154,30 @@ menuseparator {
 
 #messengerWindow[sizemode="maximized"] #titlebar-max {
     list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#restore-white) !important;
+}
+
+/*---- Calendar & Tast button on top right header ----*/
+#calendar-tab-button, #task-tab-button{
+    background-color: #eff0f1 !important;
+}
+
+/*---- Folder close icon ----*/
+.close-icon{
+  list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#close-white) !important;
+  -moz-image-region: rect(0px, 16px, 12px, -4px) !important;
+}
+
+.close-icon:hover{
+    list-style-image: url(chrome://global/skin/icons/close.png) !important;
+     -moz-image-region: rect(0, 40px, 20px, 20px) !important;
+}
+
+.close-icon[selected="true"]{
+    list-style-image: url(chrome://global/skin/icons/close.png) !important;
+    -moz-image-region: rect(0, 20px, 20px, 0) !important;
+}
+
+.close-icon[selected="true"]:hover{
+    list-style-image: url(chrome://global/skin/icons/close.png) !important;
+    -moz-image-region: rect(0, 40px, 20px, 20px) !important;
 }

--- a/themes/fulldark.css
+++ b/themes/fulldark.css
@@ -139,6 +139,8 @@ menuseparator {
 	border-bottom: 1px solid rgba(127,127,127,0.2) !important;
 }
 
+/*---- Titlebar button ----*/
+
 #titlebar-min {
     list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#minimize-white) !important;
 }
@@ -155,3 +157,17 @@ menuseparator {
     list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#restore-white) !important;
 }
 
+/*---- Folder close icon ----*/
+.close-icon{
+  list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#close-white) !important;
+  -moz-image-region: rect(0px, 16px, 12px, -4px) !important;
+}
+
+.close-icon:hover{
+    list-style-image: url(chrome://global/skin/icons/close.png) !important;
+    -moz-image-region: rect(0, 40px, 20px, 20px) !important;
+}
+
+.close-icon[selected="true"]:hover{
+    -moz-image-region: rect(0, 60px, 20px, 40px) !important;
+}

--- a/themes/monterail.css
+++ b/themes/monterail.css
@@ -100,6 +100,10 @@
 	color: var(--monterail-text-color) !important;
 }
 
+.chromeclass-toolbar, .chromeclass-toolbar * {
+	color: var(--monterail-light-text-color) !important;
+}
+
 #navigation-toolbox .menubar-text, .splitmenu-menuitem label, menucaption label, .chromeclass-toolbar menu label, .chromeclass-toolbar menuitem label, .chromeclass-toolbar .splitmenu-menuitem label, .chromeclass-toolbar menucaption label {
   color: var(--monterail-text-color) !important;
 }
@@ -139,6 +143,46 @@ menuseparator {
 	border-bottom: 1px solid rgba(127,127,127,0.2) !important;
 }
 
- .toolbarbutton-1, .toolbarbutton-menubutton-button, #composeToolbar2{
-     color: var(--dark-text-color) !important;
- }
+/*---- Titlebar button ----*/
+
+#titlebar-min {
+  list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#minimize-white) !important;
+}
+
+#titlebar-max {
+  list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#maximize-white) !important;
+}
+
+#titlebar-close {
+  list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#close-white) !important;
+}
+
+#messengerWindow[sizemode="maximized"] #titlebar-max {
+  list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#restore-white) !important;
+}
+
+/*---- Calendar & Tast button on top right header ----*/
+#calendar-tab-button, #task-tab-button{
+  background-color: #eff0f1 !important;
+}
+
+/*---- Folder close icon ----*/
+.close-icon{
+list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#close-white) !important;
+-moz-image-region: rect(0px, 16px, 12px, -4px) !important;
+}
+
+.close-icon:hover{
+  list-style-image: url(chrome://global/skin/icons/close.png) !important;
+   -moz-image-region: rect(0, 40px, 20px, 20px) !important;
+}
+
+.close-icon[selected="true"]{
+  list-style-image: url(chrome://global/skin/icons/close.png) !important;
+  -moz-image-region: rect(0, 20px, 20px, 0) !important;
+}
+
+.close-icon[selected="true"]:hover{
+  list-style-image: url(chrome://global/skin/icons/close.png) !important;
+  -moz-image-region: rect(0, 40px, 20px, 20px) !important;
+}


### PR DESCRIPTION
New view for monterail-dark-fulldark:
![immagine](https://user-images.githubusercontent.com/12801153/35931031-d94bd810-0c33-11e8-8573-cfb88f84cab2.png)
![immagine](https://user-images.githubusercontent.com/12801153/35931120-12f24a0e-0c34-11e8-9e38-49920a7527d7.png)
![immagine](https://user-images.githubusercontent.com/12801153/35931195-3e8c78e2-0c34-11e8-8e75-f8a286e7cad0.png)

Light view is changed in #94 

