### PR TITLE
Better commenting for choosing themes

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -26,17 +26,24 @@
 
 /******************************************************************/
 /*********************** SELECT THEME HERE ************************/
-@import "themes/system.css";
+/** Choose a theme by adding '/' after '/**' before the theme name *****/
+/**@import "themes/_base.css";/**/
+/**/@import "themes/dark.css";/**/        /** --> this theme is currently active
+/**@import "themes/dark-blue.css";/**/
+/**@import "themes/fulldark.css";/**/
+/**@import "themes/light.css";/**/
+/**@import "themes/monterail.css";/**/
+/**@import "themes/system.css";/**/
 /******************************************************************/
 /******************************************************************/
 
 /* Uncommment to use the dark folder pane style when using the system theme with dark menus */
-@import "tweaks/dark-folder-pane.css";
+/* @import "tweaks/dark-folder-pane.css"; */
 
 /* Select icon theme (leave commented to use default for the selected theme)*/
-/* @import "icons/lightIcons.css"; /*For dark Folder Tree and Message List*/
-/* @import "icons/lightDarkIcons.css"; /*For dark Folder Tree, with a light Message List*/
-/* @import "icons/darkIcons.css"; /*For light Folder Tree and Message List*/
+/**@import "icons/lightIcons.css";/**/ /*For dark Folder Tree and Message List*/
+/**/@import "icons/lightDarkIcons.css"; /**//*For dark Folder Tree, with a light Message List*/
+ /**@import "icons/darkIcons.css";/**/ /*For light Folder Tree and Message List*/
 
 
 /****************************************************************************/
@@ -45,6 +52,7 @@
 :root {
   /*---- General Options ----*/
   /*--default-font: var(--light-sans-font); /* Change to var(--system-font) to use your default font, or specify a font name */
+  --default-font: var(--system-font); /* Change to var(--system-font) to use your default font, or specify a font name */
   /*--menu-text-color: MenuText;*/
   
   /*---- Highlight Colors - Used if more specific ones aren't specified below ----/


### PR DESCRIPTION
userChrome.css has only single entry of the theme and it's difficult for many users to add other theme names and mess around.

I added all themes/css imports into userChrome.css and commented them. Better way to choose theme is to just uncomment it by simply adding '/' before the theme name and this simplifies a lot of things for new users and old users as well.
