### PR TITLE
Fix background for quick filter

### DIFF
--- a/themes/fulldark.css
+++ b/themes/fulldark.css
@@ -155,3 +155,6 @@ menuseparator {
     list-style-image: url(chrome://messenger/skin/icons/caption-buttons.svg#restore-white) !important;
 }
 
+#quick-filter-bar-main-bar {
+    background: var(--dark-color) !important;
+}


### PR DESCRIPTION
Quick filter in dark theme was barely readable (white on lightgrey).
This fix sets the background of the quick filter bar to dark color.