### PR TITLE
Fixed the inverted read-unread icon in dark theme

### DIFF
--- a/icons/darkIcons.css
+++ b/icons/darkIcons.css
@@ -39,8 +39,8 @@ treechildren::-moz-tree-image(threadCol) { list-style-image: url("message-list/t
 
 /* ..... read column ..... */
 .readColumnHeader { list-style-image: url("message-list/read-header-dark.svg") !important; }
-treechildren::-moz-tree-image(unreadButtonColHeader) { list-style-image: url("message-list/dot-read.svg") !important; }
-treechildren::-moz-tree-image(unreadButtonColHeader, unread) { list-style-image: url("message-list/dot-unread.svg") !important; }
+treechildren::-moz-tree-image(unreadButtonColHeader) { list-style-image: url("message-list/dot-unread.svg") !important; }
+treechildren::-moz-tree-image(unreadButtonColHeader, unread) { list-style-image: url("message-list/dot-read.svg") !important; }
 /* Unread and read are reversed for dark themes */
 
 /* ..... attachment column ..... */


### PR DESCRIPTION
In light themes the unread icon is a dark gray dot and the read icon is a light dot.
For dark themes they should be inverted.

Here are a screenshots before

![before_change](https://user-images.githubusercontent.com/349256/82179545-717f3d00-9893-11ea-8574-352775de7004.png)

and after the change

![after_change](https://user-images.githubusercontent.com/349256/82179554-76dc8780-9893-11ea-921c-a6cdb4c78b8f.png)


This solves Issue #123